### PR TITLE
fix: run preload cron via node script instead of curl

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,7 +21,10 @@ bunfig.toml
 
 # Infra & tooling that runs in CI or locally, never in the image.
 # scripts/dokploy-preview.mjs only ever runs on a GitHub runner.
+# preload-pagespeed-results.mjs is the exception: the Dokploy schedule runs it
+# with `docker exec` inside this container, so it has to ship in the image.
 scripts
+!scripts/preload-pagespeed-results.mjs
 docker-compose.yml
 Dockerfile
 .dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,11 @@ ENV NODE_ENV=production \
 COPY --from=build --chown=node:node /app/.next/standalone ./
 COPY --from=build --chown=node:node /app/.next/static ./.next/static
 COPY --from=build --chown=node:node /app/public ./public
+
+# Not part of the server — this is what the "Preload Pagespeed Results" Dokploy
+# schedule execs every 30 minutes. It needs no node_modules, only Node itself.
+COPY --from=build --chown=node:node /app/scripts/preload-pagespeed-results.mjs ./scripts/
+
 USER node
 
 EXPOSE 3000

--- a/scripts/preload-pagespeed-results.mjs
+++ b/scripts/preload-pagespeed-results.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// =====================================================================
+// Cron entrypoint for the "Preload Pagespeed Results" Dokploy schedule.
+//
+// Dokploy runs this with `docker exec` inside the already-running app
+// container, so it talks to the server over loopback rather than going back
+// out through Cloudflare and Traefik to reach the same process.
+//
+// This used to be a bare `curl https://pagespeed.bootpack.dev/...`. That
+// worked while Dokploy built the image with nixpacks, whose image happened to
+// carry curl. The image is now built from node:22-slim (see Dockerfile), which
+// ships neither curl nor wget, so every run failed with
+// `curl: command not found`. Node is the one interpreter the runtime image is
+// guaranteed to have, so the job is a Node script.
+//
+// Node builtins only: the runtime stage ships `output: "standalone"`, which is
+// just the dependencies Next traced as reachable from the server. There is no
+// node_modules tree here to import from.
+// =====================================================================
+
+// The server binds PORT (Dockerfile defaults it to 3000). Loopback, not the
+// public host: no DNS, no TLS, no edge in the path, and the job cannot fail
+// because of something happening in front of the container.
+const PORT = process.env.PORT ?? "3000";
+const ENDPOINT = `http://127.0.0.1:${PORT}/api/preload-pagespeed-results`;
+
+// The route fans out to the PageSpeed Insights API for up to 20 pages, each
+// staggered 500ms apart, and waits for all of them. Minutes is normal; the
+// timeout is only here so a wedged run cannot sit forever against a schedule
+// that fires every 30 minutes.
+const TIMEOUT_MS = Number(process.env.PRELOAD_TIMEOUT_MS ?? 10 * 60 * 1000);
+
+const log = (message) => console.log(`[preload-pagespeed-results] ${message}`);
+
+log(`GET ${ENDPOINT} (timeout ${TIMEOUT_MS}ms)`);
+
+let response;
+try {
+  response = await fetch(ENDPOINT, {
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+} catch (error) {
+  // A timeout arrives as TimeoutError, a refused connection as a TypeError
+  // wrapping the cause. Either way the run did not happen.
+  log(`request failed: ${error instanceof Error ? error.message : error}`);
+  if (error?.cause) log(`cause: ${error.cause}`);
+  process.exit(1);
+}
+
+const body = await response.text();
+
+if (!response.ok) {
+  // Exit non-zero so Dokploy records the run as failed instead of silently
+  // logging a 500 and reporting success.
+  log(`HTTP ${response.status} ${response.statusText}: ${body}`);
+  process.exit(1);
+}
+
+log(`HTTP ${response.status}: ${body}`);


### PR DESCRIPTION
## What was broken

The **Preload Pagespeed Results** Dokploy schedule runs `docker exec` inside the app container every 30 minutes. Its command was:

```
curl https://pagespeed.bootpack.dev/api/preload-pagespeed-results
```

That worked while Dokploy built the image with nixpacks, whose image happened to carry `curl`. Since #237 the image is built from `node:22-slim`, which ships neither `curl` nor `wget` — so every run since that deploy has failed with `curl: command not found`.

Confirmed against the actual production image:

```
$ docker run --rm --entrypoint bash pagespeed -c 'command -v curl; command -v wget; command -v node'
curl: ABSENT
wget: ABSENT
/usr/local/bin/node
```

The endpoint itself is healthy — hitting it directly returns `{"success":"Total pages preloaded: 20"}`.

## What changed

- **`scripts/preload-pagespeed-results.mjs`** — new cron entrypoint. Node is the one interpreter the runtime image is guaranteed to have. Builtins only, because `output: "standalone"` ships just the dependencies Next traced as reachable from the server; there is no `node_modules` tree to import from.
- **`Dockerfile`** — copies that one file into the runtime stage.
- **`.dockerignore`** — `scripts` was excluded wholesale, so un-ignore this single file. `scripts/dokploy-preview.mjs` stays out of the image.

Two behaviour changes beyond swapping the interpreter:

- It talks to the server over **loopback** (`127.0.0.1:$PORT`) instead of resolving the public host and going back out through Cloudflare and Traefik to reach the same process. No DNS, no TLS, no edge in the path.
- It **exits non-zero** on a failed request, so Dokploy records a failed run instead of logging an error as success — which is part of why this went unnoticed.

## Verification

Built the production image and ran the exact command Dokploy execs (`bash -c`, as the unprivileged `node` user) inside the running container:

```
$ docker exec ps-verify bash -c "node /app/scripts/preload-pagespeed-results.mjs"
[preload-pagespeed-results] GET http://127.0.0.1:3000/api/preload-pagespeed-results (timeout 600000ms)
[preload-pagespeed-results] HTTP 500 Internal Server Error:
exit=1
```

The 500 is expected there — that throwaway container pointed at a nonexistent database. It confirms the script is found, runs as `node`, reaches the route over loopback, and reports failure correctly.

All four paths tested standalone against a stub server: `200` → exit 0; `500` → exit 1; connection refused → exit 1; timeout → exit 1.

Also verified the `.dockerignore` negation is surgical: `scripts/preload-pagespeed-results.mjs` is in the build context, while a `COPY` of `scripts/dokploy-preview.mjs` still fails with `not found`.

## Deploy note

The Dokploy schedule command has **already** been updated to:

```
node /app/scripts/preload-pagespeed-results.mjs
```

It was failing either way, and that is reversible in one API call. But until this merges and the image carrying the script deploys, the job fails with a missing-module error rather than a missing-curl error. It starts passing on the first run after this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scheduled Pagespeed preload task for runtime environments.
  * Added configurable port and timeout settings.
  * Added detailed request logging and failure handling.
  * The task now reports unsuccessful network requests and HTTP responses clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->