### PR TITLE
fix: don't fail the whole preload run on one bad page

### DIFF
--- a/src/app/api/preload-pagespeed-results/route.ts
+++ b/src/app/api/preload-pagespeed-results/route.ts
@@ -52,15 +52,6 @@ export const GET = async () => {
     20
   );
 
-  // preload all the pages with a 500ms delay between each
-  await Promise.all(
-    pageUrlsWithStrategyToFetch.map((page, index) =>
-      new Promise((resolve) => setTimeout(resolve, 500 * index)).then(() =>
-        getPageSpeedData(page.url, page.strategy)
-      )
-    )
-  );
-
   if (pageUrlsWithStrategyToFetch.length === 0) {
     return NextResponse.json(
       {
@@ -74,7 +65,52 @@ export const GET = async () => {
     );
   }
 
+  // preload all the pages with a 500ms delay between each
+  //
+  // allSettled, not all: PageSpeed Insights fails on individual pages that
+  // Lighthouse cannot get through ("Lighthouse returned error: Something went
+  // wrong"), and getPageSpeedData throws on any non-OK response. Under
+  // Promise.all one such page rejected the whole batch, so the route 500'd and
+  // the cron went red even though the other 19 pages were fine. Worse, a page
+  // that throws never gets a row written, so it stayed in the candidate set and
+  // poisoned every subsequent run.
+  const results = await Promise.allSettled(
+    pageUrlsWithStrategyToFetch.map((page, index) =>
+      new Promise((resolve) => setTimeout(resolve, 500 * index)).then(() =>
+        getPageSpeedData(page.url, page.strategy)
+      )
+    )
+  );
+
+  const failures = results.flatMap((result, index) =>
+    result.status === "rejected"
+      ? [{ page: pageUrlsWithStrategyToFetch[index], reason: result.reason }]
+      : []
+  );
+
+  for (const { page, reason } of failures) {
+    console.error(
+      `preload failed: ${page.strategy} ${page.url}`,
+      reason instanceof Error ? reason.message : reason
+    );
+  }
+
+  const preloaded = results.length - failures.length;
+
+  // Every single page failing is not a flaky page, it is something systemic —
+  // an expired API key, no network, a dead database. Report that as an error so
+  // the schedule goes red; a handful of flaky pages should not.
+  if (preloaded === 0) {
+    return NextResponse.json(
+      {
+        error: `All ${results.length} pages failed to preload`,
+      },
+      { status: 500 }
+    );
+  }
+
   return NextResponse.json({
-    success: `Total pages preloaded: ${pageUrlsWithStrategyToFetch.length}`,
+    success: `Total pages preloaded: ${preloaded}`,
+    ...(failures.length > 0 && { failed: failures.length }),
   });
 };


### PR DESCRIPTION
## What's broken

The **Preload Pagespeed Results** Dokploy schedule has failed on all 11 of its retained runs — every 30 minutes, for hours. It is the only red schedule left on the bootpack instance.

The cron script from #240 is doing its job, and the deployed image is current. The route is what fails:

```
[preload-pagespeed-results] GET http://127.0.0.1:3000/api/preload-pagespeed-results (timeout 600000ms)
[preload-pagespeed-results] HTTP 500 Internal Server Error:
❌ Command failed
```

## Why

`getPageSpeedData` throws on any non-OK PageSpeed Insights response, and the route wrapped all 20 pages in `Promise.all` — so one rejected page took down the batch and the route 500'd with an empty body.

Probing the current candidate pages directly against PSI finds the culprit:

```
mobile  https://www.acceleratedep.com/contact  -> ERROR 500 Lighthouse returned error: Something went wrong.
desktop https://www.acceleratedep.com/contact  -> ok 1
```

The other 19 pages in the batch all scored fine. This is Lighthouse failing on one page, not a problem on our end.

It also couldn't recover on its own. A page that throws never reaches the `insert`, so it never gets a row, so it stays inside the 12-hour candidate window and lands in the next batch — poisoning every run indefinitely. That's the "every single run failed" pattern rather than an occasional flake.

## The change

- `Promise.all` → `Promise.allSettled`, so one page can't sink the other 19.
- Log each rejection with its url and strategy, so a persistently broken page is visible in the container logs instead of just producing a blank 500.
- Report `Total pages preloaded: <n>` for what actually succeeded, plus a `failed` count when some didn't.
- Still return 500 when **every** page fails — that's systemic (expired API key, no network, no database), and the schedule should go red for it. A handful of flaky pages shouldn't.
- Moved the empty-candidate early return above the fetch loop, where it reads as the guard it is (it used to sit after an already-awaited empty `Promise.all`).

## Verification

`npx tsc --noEmit` and `eslint` both clean. The failing PSI response was reproduced directly against the API using the production `GOOGLE_API_KEY`, which confirms the key itself is healthy — `https://bootpack.dev/` scores 1.0 on the same key.

Once this deploys, the schedule should go green on its next 30-minute run and record 19 of 20 pages, with the `acceleratedep.com/contact` mobile failure logged rather than fatal.